### PR TITLE
Several bug fixes:

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -276,6 +276,7 @@ func playMatch(baselinePath string, candidatePath string, params []string, flip 
 	defer baseline.Input.Close()
 	defer func() {
 		log.Println("Waiting for baseline to exit.")
+		baseline.Cmd.Process.Kill()
 		baseline.Cmd.Wait()
 	}()
 
@@ -285,6 +286,7 @@ func playMatch(baselinePath string, candidatePath string, params []string, flip 
 	defer candidate.Input.Close()
 	defer func() {
 		log.Println("Waiting for candidate to exit.")
+		candidate.Cmd.Process.Kill()
 		candidate.Cmd.Wait()
 	}()
 


### PR DESCRIPTION
- Wait for selfplay training to finish before removing the
  training directory.
- Print the value of Cmd.Wait(), the return value is the errcode
  from the subprocess not an error from the wait call, log.Fatal was
  wrong here.
- Add Cmd.Wait() calls for the subprocesses in match mode so we
  don't leave defunct processes lingering.
- Remove the bestmove print it is very noisy.