### PR TITLE
Error should actually be returned...

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -549,7 +549,7 @@ func nextGame(httpClient *http.Client, count int) error {
 		// Ensure the anonymous function stops retrying.
 		nextGame.Type = "Done"
 		if err != nil {
-			return nil
+			return err
 		}
 		return nil
 	}


### PR DESCRIPTION
Without this clients will still fast spin if training fails.