### PR TITLE
Better handling of passing arguments to lc0.

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -204,8 +204,9 @@ func createCmdWrapper() *cmdWrapper {
 func (c *cmdWrapper) launch(networkPath string, args []string, input bool) {
 	dir, _ := os.Getwd()
 	c.Cmd = exec.Command(path.Join(dir, "lc0"))
-	c.Cmd.Args = append(c.Cmd.Args, args...)
-	c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--weights=%s", networkPath))
+	// Add the "selfplay" or "uci" part first
+	c.Cmd.Args = append(c.Cmd.Args, args[0])
+	args = args[1:]
 	if *lc0Args != "" {
 		log.Println("WARNING: Option --lc0args is for testing, not production use!")
 		log.SetPrefix("TESTING: ")
@@ -223,6 +224,8 @@ func (c *cmdWrapper) launch(networkPath string, args []string, input bool) {
 		}
 		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--backend-opts=%s", *backopts))
 	}
+	c.Cmd.Args = append(c.Cmd.Args, args...)
+	c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--weights=%s", networkPath))
 	if !*debug {
 		//		c.Cmd.Args = append(c.Cmd.Args, "--quiet")
 		fmt.Println("lc0 is never quiet.")

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -207,6 +207,8 @@ func (c *cmdWrapper) launch(networkPath string, args []string, input bool) {
 	c.Cmd.Args = append(c.Cmd.Args, args...)
 	c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--weights=%s", networkPath))
 	if *lc0Args != "" {
+		log.Println("WARNING: Option --lc0args is for testing, not production use!")
+		log.SetPrefix("TESTING: ")
 		parts := strings.Split(*lc0Args, " ")
 		c.Cmd.Args = append(c.Cmd.Args, parts...)
 	}

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -226,7 +226,7 @@ func (c *cmdWrapper) launch(networkPath string, args []string, input bool) {
 		}
 		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--backend-opts=%s", *backopts))
 	}
-	if *parallel != -1 && mode == "selfplay" {
+	if *parallel > 0 && mode == "selfplay" {
 		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--parallelism=%v", *parallel))
 	}
 	c.Cmd.Args = append(c.Cmd.Args, args...)

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -41,6 +41,7 @@ var (
 	lc0Args  = flag.String("lc0args", "", "")
 	backopts = flag.String("backend-opts", "",
 		`Options for the lc0 mux. backend. Example: --backend-opts="cudnn(gpu=1)"`)
+	parallel = flag.Int("parallelism", -1, "Number of games to play in parallel (-1 for default)")
 )
 
 // Settings holds username and password.
@@ -205,7 +206,8 @@ func (c *cmdWrapper) launch(networkPath string, args []string, input bool) {
 	dir, _ := os.Getwd()
 	c.Cmd = exec.Command(path.Join(dir, "lc0"))
 	// Add the "selfplay" or "uci" part first
-	c.Cmd.Args = append(c.Cmd.Args, args[0])
+	mode := args[0]
+	c.Cmd.Args = append(c.Cmd.Args, mode)
 	args = args[1:]
 	if *lc0Args != "" {
 		log.Println("WARNING: Option --lc0args is for testing, not production use!")
@@ -223,6 +225,9 @@ func (c *cmdWrapper) launch(networkPath string, args []string, input bool) {
 			}
 		}
 		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--backend-opts=%s", *backopts))
+	}
+	if *parallel != -1 && mode == "selfplay" {
+		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--parallelism=%v", *parallel))
 	}
 	c.Cmd.Args = append(c.Cmd.Args, args...)
 	c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--weights=%s", networkPath))

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -608,9 +608,23 @@ func testEP() {
 	}
 }
 
+func hideLc0argsFlag() {
+	shown := new(flag.FlagSet)
+	flag.VisitAll(func(f *flag.Flag) {
+		if (f.Name != "lc0args") {
+			shown.Var(f.Value, f.Name, f.Usage)
+		}
+	})
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		shown.PrintDefaults()
+	}
+}
+
 func main() {
 	testEP()
 
+	hideLc0argsFlag()
 	flag.Parse()
 
 	log.SetFlags(log.LstdFlags | log.Lshortfile)


### PR DESCRIPTION
What is this patch does (as discussed in #29) :

1.  --lc0args is hidden from the help text. (Was harder than I thought it would/should be).
2. New option --backend-opts is used and passed to lc0 with a blacklist check for specific tokens. Currently only "random" is rejected.
3. No checking of --lc0args but a warning is printed that it is intended for testing and "TESTING" is printed in front of all client log output.
4. Server controlled parameters are passed last to lc0 to override user specified ones.
5. New option parallelism is introduced and passed to lc0 for selfplay games.

Currently used commands will continue to work since -lc0args is still available.