### PR TITLE
Download to tmp file and verify gzip file structure

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -6,11 +6,13 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -494,7 +496,16 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 	path := filepath.Join("networks", sha)
 	if stat, err := os.Stat(path); err == nil {
 		if stat.Size() != 0 {
-			return path, nil
+			file, _ := os.Open(path)
+			reader, _ := gzip.NewReader(file)
+			_, err = ioutil.ReadAll(reader)
+			file.Close()
+			if err != nil {
+				fmt.Printf("Deleting old network...\n")
+				os.Remove(path)
+			} else {
+				return path, nil
+			}
 		}
 	}
 

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -497,8 +497,10 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 	if stat, err := os.Stat(path); err == nil {
 		if stat.Size() != 0 {
 			file, _ := os.Open(path)
-			reader, _ := gzip.NewReader(file)
-			_, err = ioutil.ReadAll(reader)
+			reader, err := gzip.NewReader(file)
+			if err == nil {
+				_, err = ioutil.ReadAll(reader)
+			}
 			file.Close()
 			if err != nil {
 				fmt.Printf("Deleting old network...\n")

--- a/src/client/client_http.go
+++ b/src/client/client_http.go
@@ -108,14 +108,19 @@ func DownloadNetwork(httpClient *http.Client, hostname string, networkPath strin
 	if err != nil {
 		return err
 	}
-	defer r.Body.Close()
 
-	out, err := os.Create(networkPath)
+	out, err := ioutil.TempFile("", "lczero_tmp")
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 
 	_, err = io.Copy(out, r.Body)
+	r.Body.Close()
+	out.Close()
+	if err == nil {
+		err = os.Rename(out.Name(), networkPath)
+	} else {
+		os.Remove(out.Name())
+	}
 	return err
 }


### PR DESCRIPTION
The tmp file is renamed to the expected name only at the end. Tested on windows and linux.