### PR TITLE
Add lockfile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Pre-reqs:
 # (Bug workaround, using Tilps instead)
 # go get -u github.com/notnil/chess
 go get -u github.com/Tilps/chess
+go get -u github.com/nightlyone/lockfile
 
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
     GOOS: darwin
 install:
   - go get -u github.com/Tilps/chess
+  - go get -u github.com/nightlyone/lockfile
 build_script:
   - go build -o client%NAME% lc0_main.go
 artifacts:

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -524,12 +524,13 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 	os.MkdirAll("networks", os.ModePerm)
 
 	for {
-		if path, err := checkValidNetwork(sha); err == nil {
+		path, err := checkValidNetwork(sha)
+		if err == nil {
 			// There is already a valid network
 			return path, nil
 		}
 		// Otherwise, let's download it
-		err := client.DownloadNetwork(httpClient, *hostname, path, sha)
+		err = client.DownloadNetwork(httpClient, *hostname, path, sha)
 		if err != nil {
 			log.Printf("Network download failed: %v", err)
 		}

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -532,7 +532,8 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 		}
 
 		// Otherwise, let's download it
-		lock, err := lockfile.New(filepath.Abs(filepath.Join("networks", sha + ".lck")))
+		lockfile, _ := filepath.Abs(filepath.Join("networks", sha + ".lck"))
+		lock, err := lockfile.New(lockfile)
 		if err != nil {
 			log.Printf("Cannot init lock: %v", err)
 		}

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -598,7 +598,7 @@ func nextGame(httpClient *http.Client, count int) error {
 		log.Println("Starting match")
 		result, pgn, version, err := playMatch(networkPath, candidatePath, serverParams, nextGame.Flip)
 		if err != nil {
-			log.Fatalf("playMatch: %v", err)
+			log.Printf("playMatch: %v", err)
 			return err
 		}
 		extraParams := getExtraParams()

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -518,10 +518,13 @@ func checkValidNetwork(sha string) (string, error) {
 
 func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, error) {
 	
+	// TODO
+	// Commented out temporarily, this is never run on previous code
 	// if clearOld {
 	// 	// Clean out any old networks
 	// 	os.RemoveAll("networks")
 	// }
+	
 	os.MkdirAll("networks", os.ModePerm)
 
 	for {

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -6,11 +6,13 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -494,7 +496,16 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 	path := filepath.Join("networks", sha)
 	if stat, err := os.Stat(path); err == nil {
 		if stat.Size() != 0 {
-			return path, nil
+			file, _ := os.Open(path)
+			reader, _ := gzip.NewReader(file)
+			_, err = ioutil.ReadAll(reader)
+			file.Close()
+			if err != nil {
+				fmt.Printf("Deleting old network...\n")
+				os.Remove(path)
+			} else {
+				return path, nil
+			}
 		}
 	}
 

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -532,7 +532,7 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 		}
 
 		// Otherwise, let's download it
-		lock, err := lockfile.New(filepath.join("networks", sha + ".lck"))
+		lock, err := lockfile.New(filepath.Join("networks", sha + ".lck"))
 		if err != nil {
 			log.Printf("Cannot init lock: %v", err)
 		}

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -516,14 +516,25 @@ func checkValidNetwork(sha string) (string, error) {
 	return path, err
 }
 
+func removeAllExcept(dir string, sha string) (error) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		if file.Name() == sha {
+			continue
+		}
+		fmt.Printf("Removing %v\n", file.Name())
+		err := os.RemoveAll(filepath.Join(dir, file.Name()))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, error) {
-	
-	// TODO
-	// Commented out temporarily, this is never run on previous code
-	// if clearOld {
-	// 	// Clean out any old networks
-	// 	os.RemoveAll("networks")
-	// }
 	
 	os.MkdirAll("networks", os.ModePerm)
 
@@ -531,7 +542,15 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 		// Loop until a valid network is found
 		path, err := checkValidNetwork(sha)
 		if err == nil {
-			// There is already a valid network. Use it
+			// There is already a valid network. Use it.
+
+			if clearOld {
+				err := removeAllExcept("networks", sha)
+				if err != nil {
+					log.Printf("Failed to remove old network(s): %v", err)
+				}
+			}
+
 			return path, nil
 		}
 

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -495,22 +495,20 @@ func train(httpClient *http.Client, ngr client.NextGameResponse,
 func checkValidNetwork(dir string, sha string) (string, error) {
 	// Sha already exists?
 	path := filepath.Join(dir, sha)
-	stat, err := os.Stat(path)
+	_, err := os.Stat(path)
 	if err == nil {
-		if stat.Size() != 0 {
-			file, _ := os.Open(path)
-			reader, err := gzip.NewReader(file)
-			if err == nil {
-				_, err = ioutil.ReadAll(reader)
-			}
-			file.Close()
-			if err != nil {
-				fmt.Printf("Deleting invalid network...\n")
-				os.Remove(path)
-				return path, err
-			} else {
-				return path, nil
-			}
+		file, _ := os.Open(path)
+		reader, err := gzip.NewReader(file)
+		if err == nil {
+			_, err = ioutil.ReadAll(reader)
+		}
+		file.Close()
+		if err != nil {
+			fmt.Printf("Deleting invalid network...\n")
+			os.Remove(path)
+			return path, err
+		} else {
+			return path, nil
 		}
 	}
 	return path, err

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -497,8 +497,10 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 	if stat, err := os.Stat(path); err == nil {
 		if stat.Size() != 0 {
 			file, _ := os.Open(path)
-			reader, _ := gzip.NewReader(file)
-			_, err = ioutil.ReadAll(reader)
+			reader, err := gzip.NewReader(file)
+			if err == nil {
+				_, err = ioutil.ReadAll(reader)
+			}
 			file.Close()
 			if err != nil {
 				fmt.Printf("Deleting old network...\n")

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -532,7 +532,7 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 		}
 
 		// Otherwise, let's download it
-		lock, err := lockfile.New(filepath.Join("networks", sha + ".lck"))
+		lock, err := lockfile.New(filepath.Abs(filepath.Join("networks", sha + ".lck")))
 		if err != nil {
 			log.Printf("Cannot init lock: %v", err)
 		}

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -522,7 +522,7 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 	// 	// Clean out any old networks
 	// 	os.RemoveAll("networks")
 	// }
-	// os.MkdirAll("networks", os.ModePerm)
+	os.MkdirAll("networks", os.ModePerm)
 
 	for {
 		path, err := checkValidNetwork(sha)

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -532,8 +532,8 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 		}
 
 		// Otherwise, let's download it
-		lockfile, _ := filepath.Abs(filepath.Join("networks", sha + ".lck"))
-		lock, err := lockfile.New(lockfile)
+		lockpath, _ := filepath.Abs(filepath.Join("networks", sha + ".lck"))
+		lock, err := lockfile.New(lockpath)
 		if err != nil {
 			log.Printf("Cannot init lock: %v", err)
 		}

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -505,7 +505,7 @@ func checkValidNetwork(sha string) (string, error) {
 			}
 			file.Close()
 			if err != nil {
-				fmt.Printf("Deleting old network...\n")
+				fmt.Printf("Deleting invalid network...\n")
 				os.Remove(path)
 				return path, err
 			} else {

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -537,7 +537,7 @@ func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, err
 			log.Printf("Cannot init lock: %v", err)
 		}
 		err = lock.TryLock()
-		if err != nill {
+		if err != nil {
 			log.Printf("Cannot lock: %v", err)
 		} else {
 			err = client.DownloadNetwork(httpClient, *hostname, path, sha)

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -506,13 +506,13 @@ func checkValidNetwork(sha string) (string, error) {
 			if err != nil {
 				fmt.Printf("Deleting old network...\n")
 				os.Remove(path)
-				return "", err
+				return path, err
 			} else {
 				return path, nil
 			}
 		}
 	}
-	return "", err
+	return path, err
 }
 
 func getNetwork(httpClient *http.Client, sha string, clearOld bool) (string, error) {

--- a/src/client/client_http.go
+++ b/src/client/client_http.go
@@ -119,8 +119,8 @@ func DownloadNetwork(httpClient *http.Client, hostname string, networkPath strin
 	out.Close()
 	if err == nil {
 		err = os.Rename(out.Name(), networkPath)
-	} else {
-		os.Remove(out.Name())
 	}
+	// Ensure tmpfile is erased
+	os.Remove(out.Name())
 	return err
 }

--- a/src/client/client_http.go
+++ b/src/client/client_http.go
@@ -109,7 +109,8 @@ func DownloadNetwork(httpClient *http.Client, hostname string, networkPath strin
 		return err
 	}
 
-	out, err := ioutil.TempFile("networks", sha + "_tmp")
+	dir, _ := filepath.Split(networkPath)
+	out, err := ioutil.TempFile(dir, sha + "_tmp")
 	if err != nil {
 		return err
 	}

--- a/src/client/client_http.go
+++ b/src/client/client_http.go
@@ -108,14 +108,19 @@ func DownloadNetwork(httpClient *http.Client, hostname string, networkPath strin
 	if err != nil {
 		return err
 	}
-	defer r.Body.Close()
 
-	out, err := os.Create(networkPath)
+	out, err := ioutil.TempFile("", "lczero_tmp")
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 
 	_, err = io.Copy(out, r.Body)
+	r.Body.Close()
+	out.Close()
+	if err == nil {
+		err = os.Rename(out.Name(), networkPath)
+	} else {
+		os.Remove(out.Name())
+	}
 	return err
 }

--- a/src/client/client_http.go
+++ b/src/client/client_http.go
@@ -109,7 +109,7 @@ func DownloadNetwork(httpClient *http.Client, hostname string, networkPath strin
 		return err
 	}
 
-	out, err := ioutil.TempFile("", "lczero_tmp")
+	out, err := ioutil.TempFile("networks", sha + "_tmp")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR extends that of #43 
This PR:
- checks if the downloaded network is a valid gzip
- uses lockfile to ensure that only one client is downloading at any time, and other clients may takeover if download failed or that client terminates
- at the beginning of training games (after playMatch), all older networks that is not the current one is deleted
- allows client to sleep loop when playMatch error. This allows low gpu memory clients to only contribute to training games

Lockfile support using [github.com/nightlyone/lockfile](https://github.com/nightlyone/lockfile)

Only tested on Ubuntu.
Edit: tested on Windows by @borg323 