### PR TITLE
Get KeepTime from the server 

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -46,6 +46,7 @@ var (
 		`Options for the lc0 mux. backend. Example: --backend-opts="cudnn(gpu=1)"`)
 	parallel = flag.Int("parallelism", -1, "Number of games to play in parallel (-1 for default)")
 	useTestServer = flag.Bool("use-test-server", false, "Set host name to test server.")
+	keep     = flag.Bool("keep", false, "Do not delete old network files")
 )
 
 // Settings holds username and password.
@@ -624,7 +625,7 @@ func nextGame(httpClient *http.Client, count int) error {
 	}
 
 	if nextGame.Type == "train" {
-		networkPath, err := getNetwork(httpClient, nextGame.Sha, true)
+		networkPath, err := getNetwork(httpClient, nextGame.Sha, !*keep)
 		if err != nil {
 			return err
 		}

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -665,7 +665,6 @@ func checkValidNetwork(dir string, sha string) (string, error) {
 	return path, err
 }
 
-
 func removeAllExcept(dir string, sha string, keepTime string) error {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
@@ -783,7 +782,9 @@ func nextGame(httpClient *http.Client, count int) error {
 		if *keep {
 			keepTime = inf
 		} else if keepTime == "" {
-			keepTime = "0s"
+			// Four hours should be enough for clients serving 2 parallel runs in
+			// the same directory, even after one or two failed failed promotions.
+			keepTime = "4h"
 		}
 		networkPath, err := getNetwork(httpClient, nextGame.Sha, keepTime)
 		if err != nil {

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -47,6 +47,7 @@ var (
 	parallel = flag.Int("parallelism", -1, "Number of games to play in parallel (-1 for default)")
 	useTestServer = flag.Bool("use-test-server", false, "Set host name to test server.")
 	keep     = flag.Bool("keep", false, "Do not delete old network files")
+	keepTime = flag.String("keep-time", "12h", "Delete network files older than this")
 )
 
 // Settings holds username and password.
@@ -522,6 +523,10 @@ func removeAllExcept(dir string, sha string) (error) {
 		if file.Name() == sha {
 			continue
 		}
+		timeLimit, _ := time.ParseDuration(*keepTime)
+		if time.Since(file.ModTime()) < timeLimit {
+			continue
+		}
 		fmt.Printf("Removing %v\n", file.Name())
 		err := os.RemoveAll(filepath.Join(dir, file.Name()))
 		if err != nil {
@@ -716,6 +721,10 @@ func main() {
 	}
 	if len(*password) == 0 {
 		log.Fatal("You must specify a non-empty password")
+	}
+	_, err :=time.ParseDuration(*keepTime)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	httpClient := &http.Client{}

--- a/src/client/client_http.go
+++ b/src/client/client_http.go
@@ -85,6 +85,7 @@ type NextGameResponse struct {
 	Params       string
 	Flip         bool
 	MatchGameId  uint
+	KeepTime     string
 }
 
 func NextGame(httpClient *http.Client, hostname string, params map[string]string) (NextGameResponse, error) {


### PR DESCRIPTION
With this the client gets KeepTime from the server (initially was the `-keep-time=xxx` option), to only delete networks older than the specified time. This is in addition to the `-keep` option. 

The default is to not delete nets received in the last 4 hours if no KeepTime is received and `-keep` is not given. This should be enough for clients serving two runs in the same directory even if a couple of nets fail to promote.