### PR TITLE
Autodetect cudnn-fp16 and re-enable --gpu option

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -797,10 +797,11 @@ func main() {
 	startTime = time.Now()
 	for i := 0; ; i++ {
 		err := nextGame(httpClient, i)
-		if err.Error() == "retry" {
-			time.Sleep(1 * time.Second)
-			continue
-		} else if err != nil {
+		if err != nil {
+			if err.Error() == "retry" {
+				time.Sleep(1 * time.Second)
+				continue
+			}
 			log.Print(err)
 			log.Print("Sleeping for 30 seconds...")
 			time.Sleep(30 * time.Second)

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -45,7 +45,7 @@ var (
 	hostname = flag.String("hostname", "http://api.lczero.org", "Address of the server")
 	user     = flag.String("user", "", "Username")
 	password = flag.String("password", "", "Password")
-//	gpu      = flag.Int("gpu", -1, "ID of the OpenCL device to use (-1 for default, or no GPU)")
+	gpu      = flag.Int("gpu", 0, "GPU to use (default 0, ignored if --backend-opts used)")
 //	debug    = flag.Bool("debug", false, "Enable debug mode to see verbose output and save logs")
 	lc0Args  = flag.String("lc0args", "", "")
 	backopts = flag.String("backend-opts", "",
@@ -272,10 +272,12 @@ func (c *cmdWrapper) launch(networkPath string, args []string, input bool) {
 		}
 		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--backend-opts=%s", *backopts))
 	} else if hasCudnnFp16 {
-		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--backend-opts=backend=cudnn-fp16"))
+		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--backend-opts=backend=cudnn-fp16,gpu=%v", *gpu))
 		if parallelism <= 0 {
 			parallelism = 32
 		}
+	} else if hasOpenCL {
+		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--backend-opts=backend=opencl,gpu=%v", *gpu))
 	}
 	if parallelism > 0 && mode == "selfplay" {
 		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--parallelism=%v", parallelism))
@@ -308,7 +310,7 @@ func (c *cmdWrapper) launch(networkPath string, args []string, input bool) {
 			case strings.Contains(line, "Your GPU doesn't support FP16"):
 				if *backopts == "" && hasCudnn {
 					log.Println("cudnn-fp16 backend not available, switching to cudnn")
-					*backopts = "backend=cudnn"
+					*backopts = fmt.Sprintf("backend=cudnn,gpu=%v", *gpu)
 					c.Retry <- true
 				} else {
 					log.Fatal("cudnn-fp16 backend not available")

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -515,6 +515,12 @@ func train(httpClient *http.Client, ngr client.NextGameResponse,
 			}
 		case gi, ok := <-c.gi:
 			if !ok {
+				// Under windows we don't get the exception, so also check here.
+				if hasCudnnFp16 && totalGames==0 && *backopts==""{
+					log.Println("GPU probably doesn't support the cudnn-fp16 backend")
+					hasCudnnFp16=false
+					return errors.New("retry")
+				}
 				log.Printf("GameInfo channel closed, exiting train loop")
 				done = true
 				break

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -233,11 +233,14 @@ func checkLc0() {
 	if bytes.Contains(out, []byte("blas")) {
 		hasBlas = true
 	}
-	if bytes.Contains(out, []byte("cudnn")) {
-		hasCudnn = true
-	}
 	if bytes.Contains(out, []byte("cudnn-fp16")) {
 		hasCudnnFp16 = true
+	}
+	if bytes.Contains(out, []byte("cudnn")) {
+		hasCudnn = true
+		if hasCudnnFp16 && bytes.Index(out, []byte("cudnn")) == bytes.LastIndex(out, []byte("cudnn")) {
+			hasCudnn = false
+		}
 	}
 	if bytes.Contains(out, []byte("opencl")) {
 		hasOpenCL = true

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -785,6 +785,7 @@ func main() {
 	for i := 0; ; i++ {
 		err := nextGame(httpClient, i)
 		if err.Error() == "retry" {
+			time.Sleep(1 * time.Second)
 			continue
 		} else if err != nil {
 			log.Print(err)


### PR DESCRIPTION
This pr does several things:
1. Checks that lc0 runs early, before downloading anything
2. If no --backend-opts are given, and cudnn is available, cudnn-fp16 is tried first and if no parallelism is given 32 is used with it.
3. If cudnn-fp16 is not available, the cudnn bckend is used immediately
4. the --gpu option can select gpu, but only if --backend-opts is not used.