### PR TITLE
prefetch next net before terminating game

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -652,6 +652,10 @@ func nextGame(httpClient *http.Client, count int) error {
 					return
 				}
 				if ng.Type != nextGame.Type || ng.Sha != nextGame.Sha {
+					if ng.Type == "match" {
+						// Prefetch the next net before terminating game.
+						getNetwork(httpClient, ng.CandidateSha, false)
+					}
 					pendingNextGame = &ng
 					doneCh <- true
 					close(doneCh)


### PR DESCRIPTION
Currently selfplay stops before downloading the nets for the next match. Downloading a net takes a bit more than 30 sec for me, and with a new net every 30 minutes, this adds up. This patch prefetches the candidate net before terminating selfplay and starting the match.