### PR TITLE
Fast matches

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -757,7 +757,7 @@ func nextGame(httpClient *http.Client, count int) error {
 			return err
 		}
 		log.Println("Starting match")
-	    possibleNextGame, err := playMatch(httpClient, nextGame, networkPath, candidatePath, serverParams)
+		possibleNextGame, err := playMatch(httpClient, nextGame, networkPath, candidatePath, serverParams)
 		if err != nil {
 			log.Printf("playMatch: %v", err)
 			return err


### PR DESCRIPTION
Use selfplay to run matches instead of custom uci mode handling.

Server will need to send more command line flags down, but otherwise this seems to work.

I've not yet gone through the code looking for code paths that were only used for the uci system.  Just barely got it to work.