### PR TITLE
log #games/day

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -161,7 +161,9 @@ func uploadGame(httpClient *http.Client, path string, pgn string,
 	}
 
 	totalGames++
-	log.Printf("Completed %d games in %s time", totalGames, time.Since(startTime))
+	var duration = time.Since(startTime).Hours()
+	var speed = float64(totalGames) / duration * 24
+	log.Printf("Completed %d games in %s time (%f games/day)", totalGames, duration, speed)
 
 	err := os.Remove(path)
 	if err != nil {

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -161,9 +161,9 @@ func uploadGame(httpClient *http.Client, path string, pgn string,
 	}
 
 	totalGames++
-	var duration = time.Since(startTime).Hours()
-	var speed = float64(totalGames) / duration * 24
-	log.Printf("Completed %d games in %s time (%f games/day)", totalGames, duration, speed)
+	var duration = time.Since(startTime)
+	var speed = int(float64(totalGames) / duration.Hours() * 24)
+	log.Printf("Completed %d games in %s time (%d games/day)", totalGames, duration, speed)
 
 	err := os.Remove(path)
 	if err != nil {


### PR DESCRIPTION
To enable easy comparison with top (active) users on https://lczero.org/

Output example:
`2019/01/31 10:58:19 lc0_main.go:166: Completed 77 games in 8m18.227504604s time (13352 games/day)
`

Comparing to https://lczero.org/
![screenshot from 2019-01-31 11-06-08](https://user-images.githubusercontent.com/123111/52025608-5080c480-2548-11e9-81e1-40b51f1b5c3c.png)
