### PR TITLE
Add num-games parameter to limit selfplay training games

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -646,6 +646,11 @@ func train(httpClient *http.Client, ngr client.NextGameResponse,
 			testedCudnnFp16 = true
 			fmt.Printf("Uploading game: %d\n", numGames)
 			numGames++
+
+			if numGames > *targetGames {
+				done = true
+			}
+
 			progressOrKill = true
 			trainDirHolder[0] = path.Dir(gi.fname)
 			log.Printf("trainDir=%s", trainDirHolder[0])
@@ -953,7 +958,7 @@ func main() {
 
 	httpClient := &http.Client{}
 	startTime = time.Now()
-	for i := 0; *targetGames == 0 || i < *targetGames; i++ {
+	for i := 0; *targetGames == 0 || totalGames < *targetGames; i++ {
 		err := nextGame(httpClient, i)
 		if err != nil {
 			if err.Error() == "retry" {

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -645,12 +645,11 @@ func train(httpClient *http.Client, ngr client.NextGameResponse,
 			}
 			testedCudnnFp16 = true
 			fmt.Printf("Uploading game: %d\n", numGames)
-			numGames++
-
-			if numGames > *targetGames {
+			if numGames == *targetGames {
 				done = true
+				c.Cmd.Process.Kill()
 			}
-
+			numGames++
 			progressOrKill = true
 			trainDirHolder[0] = path.Dir(gi.fname)
 			log.Printf("trainDir=%s", trainDirHolder[0])
@@ -962,8 +961,6 @@ func main() {
 		err := nextGame(httpClient, i)
 		if err != nil {
 			if err.Error() == "retry" {
-				// Decrease game count as this one didn't work
-				i--
 				time.Sleep(1 * time.Second)
 				continue
 			}

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -943,6 +943,11 @@ func main() {
 		*hostname = "http://testserver.lczero.org"
 	}
 
+	if !*trainOnly && *targetGames != 0 {
+		log.Println("num-games is not compatable with matches. Playing infinite games instead.")
+		*targetGames = 0
+	}
+
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	if len(*user) == 0 || len(*password) == 0 {
 		*user, *password = readSettings("settings.json")

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -57,6 +57,7 @@ var (
 	keep          = flag.Bool("keep", false, "Do not delete old network files")
 	version       = flag.Bool("version", false, "Print version and exit.")
 	trainOnly     = flag.Bool("train-only", false, "Do not play match games")
+	targetGames   = flag.Int("num-games", 0, "Only play this many games")
 )
 
 // Settings holds username and password.
@@ -224,7 +225,7 @@ func convertMovesToPGN(moves []string, result string) string {
 			to_append = "1-0"
 		} else if result == "blackwon" {
 			to_append = "0-1"
-		}	
+		}
 		b = []byte(strings.TrimRight(b_str, "*") + to_append)
 	}
 	game2.UnmarshalText(b)
@@ -952,10 +953,12 @@ func main() {
 
 	httpClient := &http.Client{}
 	startTime = time.Now()
-	for i := 0; ; i++ {
+	for i := 0; *targetGames == 0 || i < *targetGames; i++ {
 		err := nextGame(httpClient, i)
 		if err != nil {
 			if err.Error() == "retry" {
+				// Decrease game count as this one didn't work
+				i--
 				time.Sleep(1 * time.Second)
 				continue
 			}
@@ -965,4 +968,5 @@ func main() {
 			continue
 		}
 	}
+	log.Print("Target number of games reached")
 }


### PR DESCRIPTION
I'm working on integrating the existing client with Boinc and found it very useful to be able to limit the number of games produced by the client.

These changes just add a parameter called num-games which only works in conjunction with train-only. If specified the client exits when that many games have been generated.

Obviously I can just compile my own version if you don't think it's useful in any other contexts.