### PR TITLE
rename networks directory

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -728,7 +728,7 @@ func acquireLock(dir string, sha string) (lockfile.Lockfile, error) {
 }
 
 func getNetwork(httpClient *http.Client, sha string, keepTime string) (string, error) {
-	dir := "client_networks"
+	dir := "client-cache"
 	os.MkdirAll(dir, os.ModePerm)
 	if keepTime != inf {
 		err := removeAllExcept(dir, sha, keepTime)

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -728,7 +728,7 @@ func acquireLock(dir string, sha string) (lockfile.Lockfile, error) {
 }
 
 func getNetwork(httpClient *http.Client, sha string, keepTime string) (string, error) {
-	dir := "networks"
+	dir := "client_networks"
 	os.MkdirAll(dir, os.ModePerm)
 	if keepTime != inf {
 		err := removeAllExcept(dir, sha, keepTime)


### PR DESCRIPTION
It was a bad idea to have the client use the "networks" directory - lc0 also searches in it by default and running the client in the same directory (where our pre-compiled windows packages have it) will:
1. Delete all networks there, even if they were downloaded by the user.
2. Get a new network, that lc0 will now use as default since it is newer.