### PR TITLE
be careful with the dx backend

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -330,7 +330,7 @@ func (c *cmdWrapper) launch(networkPath string, otherNetPath string, args []stri
 		if !hasBlas {
 			log.Fatalf("Dx backend cannot be validated")
 		}
-		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--backend-opts=check(freq=.01,dx,fp16=false%v)", sGpu))
+		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--backend-opts=check(freq=.01,atol=5e-1,dx%v)", sGpu))
 	} else if hasOpenCL {
 		c.Cmd.Args = append(c.Cmd.Args, fmt.Sprintf("--backend-opts=backend=opencl%v", sGpu))
 	}


### PR DESCRIPTION
For now, the dx backend is only run in 32 bit mode through the check backend so that 1% of its output can be verified using blas. We can probably get away with an even lower check rate, but 1% seemed like a good starting value.