### PR TITLE
Updates for the dx backend

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -45,7 +45,7 @@ var (
 	hasBlas         bool
 	hasDx           bool
 	testedCudnnFp16 bool
-	testedDx        bool
+	testedDxNet     string
 
 	settingsPath = "settings.json"
 	defaultLocalHost = "Unknown"
@@ -346,12 +346,14 @@ func (c *cmdWrapper) launch(networkPath string, otherNetPath string, args []stri
 	if *gpu >= 0 {
 		sGpu = fmt.Sprintf(",gpu=%v", *gpu)
 	}
-	if hasDx && !testedDx {
+	// Check the dx12 backend if it is the first time or we changed net, but only if no higher
+	// priority backend is available.
+	if !hasCudnnFp16 && !hasCudnn && hasDx && testedDxNet != networkPath {
 		checkDx(networkPath)
-		testedDx = true;
+		testedDxNet = networkPath;
 	}
 	if *backopts != "" {
-		// Check agains small token blacklist, currently only "random"
+		// Check against small token blacklist, currently only "random"
 		tokens := regexp.MustCompile("[,=().0-9]").Split(*backopts, -1)
 		for _, token := range tokens {
 			switch token {


### PR DESCRIPTION
1. Before starting, runs the equivalent of the check_dx script to guard against driver errors.
2. Keeps the continuous checks, but reduces the check frequency to 1e-5 (about 1 check every 50 games)
3. Stops setting the `-train-only` flag by default.
