### PR TITLE
option and default directory for config file

### DIFF
--- a/lc0_main.go
+++ b/lc0_main.go
@@ -1136,9 +1136,11 @@ func main() {
 			configDir = filepath.Join(configDir, "lc0")
 			_, err = os.Stat(configDir)
 			if os.IsNotExist(err) {
-				err = os.MkdirAll(configDir, os.ModePerm)
+				err = os.Mkdir(configDir, os.ModePerm)
 			}
-			*settingsPath = filepath.Join(configDir, *settingsPath)
+			if err == nil {
+				*settingsPath = filepath.Join(configDir, *settingsPath)
+			}
 		}
 	}
 

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -52,7 +52,7 @@ var (
 	defaultLocalHost = "Unknown"
 	gpuType          = "Unknown"
 
-	localHost = flag.String("localhost", "", "Localhost name to send to the server when reporting (defaults to Unknown, overridden by settings.json)")
+	localHost = flag.String("localhost", "", "Localhost name to send to the server when reporting\n(defaults to Unknown, overridden by the configuration file)")
 	hostname  = flag.String("hostname", "http://api.lczero.org", "Address of the server")
 	user      = flag.String("user", "", "Username")
 	password  = flag.String("password", "", "Password")


### PR DESCRIPTION
With this, `settings.json` is renamed to `lc0-training-client-config.json` and is stored in `$XDG_CONFIG_HOME` or `$HOME/.config` in linux or `$HOME//Library/Preferences` in macos. The current directory is used under windows or if the environment variables are not defined.

The `-config` option is added to override the default file and location. 