### PR TITLE
linux autoupdate script

### DIFF
--- a/client.sh
+++ b/client.sh
@@ -6,15 +6,15 @@
 trap "exit" INT
 
 rm -f lc0
-git clone --recurse-submodules https://github.com/LeelaChessZero/lc0.git
+git clone --depth 1 --recurse-submodules https://github.com/LeelaChessZero/lc0.git
 TAG=
 ERR=
 FIRST=true
-while :
+while [ -d lc0 ]
 do
   cd lc0
 
-  git fetch --tags --all
+  git fetch --tags --depth 1
   NEW_TAG=$(git tag --list |grep -v rc |tail -1)
   if [ "$TAG" == "$NEW_TAG" ]
   then

--- a/client.sh
+++ b/client.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Autoupdate script for lc0 client. Use: "./client.sh" followed by any other
+# client options. If you need to override system compiler you can run it
+# setting CC and CXX, e.g. "CC=gcc-8 CXX=g++-8 ./client.sh".
+
+trap "exit" INT
+
+rm -f lc0
+git clone --recurse-submodules https://github.com/LeelaChessZero/lc0.git
+TAG=
+ERR=
+FIRST=true
+while :
+do
+  cd lc0
+
+  git fetch --tags --all
+  NEW_TAG=$(git tag --list |grep -v rc |tail -1)
+  if [ "$TAG" == "$NEW_TAG" ]
+  then
+    if [ $ERR -eq 5 ]
+    then
+      NEW_TAG=$(git tag --list |grep rc |tail -1)
+    else
+      NEW_TAG=$(git tag --list |grep -v rc |tail -2 |head -1)
+   fi
+  fi
+  TAG=$NEW_TAG
+  git checkout $TAG
+
+  git submodule update --remote
+  git submodule update --checkout
+  rm -rf build
+  meson build --buildtype release -Db_lto=true -Dgtest=false
+
+  cd build
+  ninja
+  cd ../..
+
+  rm -f lc0-training-client-linux
+  curl -s -L https://github.com/LeelaChessZero/lczero-client/releases/latest | egrep -o '/LeelaChessZero/lczero-client/releases/download/.*/lc0-training-client-linux' | head -n 1 | wget --base=https://github.com/ -i -
+  chmod +x lc0-training-client-linux
+
+  PATH=lc0/build ./lc0-training-client-linux "$@"
+  ERR=$?
+  if [ $ERR -ne 5 ] && $FIRST
+  then
+    break
+  fi
+  FIRST=false
+  echo Update needed, starting process shortly.
+  sleep 60
+done
+
+


### PR DESCRIPTION
Simple script to download the client, build lc0 and start training. Tries to update both when the client complains or there is a crash. The update logic is:
- Always get the latest client.
- If the client signals an update alternate between latest rc and non-rc lc0 tags.
- If there is a crash and is not the first pass alternate between the last two non-rc lc0 tags.