### PR TITLE
Change to a different locking library that uses actual flock

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
     GOOS: darwin
 install:
   - go get -u github.com/Tilps/chess
-  - go get -u github.com/nightlyone/lockfile
+  - go get -u github.com/gofrs/flock
 build_script:
   - go build -o lc0-training-client%NAME% lc0_main.go
 artifacts:

--- a/lc0_main.go
+++ b/lc0_main.go
@@ -32,7 +32,7 @@ import (
 	"client"
 
 	"github.com/Tilps/chess"
-	"github.com/nightlyone/lockfile"
+	"github.com/gofrs/flock"
 )
 
 var (
@@ -812,16 +812,12 @@ func removeAllExcept(dir string, sha string, keepTime string) error {
 	return nil
 }
 
-func acquireLock(dir string, sha string) (lockfile.Lockfile, error) {
+func acquireLock(dir string, sha string) (*flock.Flock, bool, error) {
 	lockpath, _ := filepath.Abs(filepath.Join(dir, sha+".lck"))
-	lock, err := lockfile.New(lockpath)
-	if err != nil {
-		// Unknown error. Exit.
-		log.Fatalf("Cannot init lockfile: %v", err)
-	}
+	lock := flock.New(lockpath)
 	// Attempt to acquire lock
-	err = lock.TryLock()
-	return lock, err
+	success, err := lock.TryLock()
+	return lock, success, err
 }
 
 func makeCacheDir(dir string) string {
@@ -870,10 +866,10 @@ func getNetwork(httpClient *http.Client, sha string, keepTime string) (string, e
 	}
 
 	// Otherwise, let's download it
-	lock, err := acquireLock(dir, sha)
+	lock, lockHeld, err := acquireLock(dir, sha)
 
-	if err != nil {
-		if err == lockfile.ErrBusy {
+	if err != nil || !lockHeld {
+		if !lockHeld {
 			log.Println("Download initiated by other client - waiting")
 			for i := 0; i < 60; i++ {
 				time.Sleep(time.Second)
@@ -946,10 +942,10 @@ func getBook(httpClient *http.Client, book_url string, sha string) (string, erro
 	}
 
 	// Otherwise, let's download it
-	lock, err := acquireLock(dir, book_name)
+	lock, lockHeld, err := acquireLock(dir, book_name)
 
-	if err != nil {
-		if err == lockfile.ErrBusy {
+	if err != nil || !lockHeld {
+		if !lockHeld {
 			log.Println("Book download initiated by other client")
 			return "", err
 		} else {


### PR DESCRIPTION
 This might work on NFSv4 across multiple machines for cluster users. The old one relied upon checking pid out of file contents and assuming if it couldn't find PID the lock was stale.

However its unclear if this library will work on mac.  Will need testing.