### PR TITLE
Use pinned modules for Appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ clone_folder: c:\gopath\src\github.com\LeelaChessZero\lczero-client
 
 environment:
   GOPATH: c:\gopath;c:\gopath\src\github.com\LeelaChessZero\lczero-client\
+  GO111MODULE: on
   matrix:
   - NAME: .exe
     GOOS: windows
@@ -12,10 +13,9 @@ environment:
   - NAME: -mac
     GOOS: darwin
 install:
-  - go get -u github.com/Tilps/chess
-  - go get -u github.com/gofrs/flock
+  - go mod download
 build_script:
-  - go build -o lc0-training-client%NAME% lc0_main.go
+  - go build -mod=readonly -o lc0-training-client%NAME% lc0_main.go
 artifacts:
   - path: lc0-training-client$(NAME)
     name: lc0-training-client
@@ -26,4 +26,3 @@ deploy:
       secure: USFAdwQKTXqOXQjCYQfzWvzRpUhvqJLBkN4hbOg+j876vDxGZHt9bMYayb5evePp
     on:
       appveyor_repo_tag: true
-

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/LeelaChessZero/lczero-client
 go 1.15
 
 require (
+	github.com/gofrs/flock v0.8.1
 	github.com/Tilps/chess v0.0.0-20200409092358-c35715299813
-	github.com/nightlyone/lockfile v1.0.1-0.20201014160207-368fd4d5d6ae
 )
 
 replace github.com/LeelaChessZero/lczero-client => ./

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
+github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
+github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/Tilps/chess v0.0.0-20200409092358-c35715299813 h1:9SCZ8ooOu4zJEgPuv90hPtkTT5XEIq1K0j2/Jrunsb4=
 github.com/Tilps/chess v0.0.0-20200409092358-c35715299813/go.mod h1:p5ClvMMzXkXDcSis21aF6thPWChCbR1YRrTGbEhwA6w=
-github.com/nightlyone/lockfile v1.0.1-0.20201014160207-368fd4d5d6ae h1:ZD/X4pxMoJCbiaaxKpSl5hxmr0l0TTiVrF1BPvKThU4=
-github.com/nightlyone/lockfile v1.0.1-0.20201014160207-368fd4d5d6ae/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=


### PR DESCRIPTION
Codex did that (also created the PR). Fixes appveyor builds.

## Summary
- stop Appveyor from upgrading dependencies with `go get -u` and switch it to `go mod download`
- enable module mode in Appveyor and build with `-mod=readonly` so CI uses the pinned dependency graph
- replace the stale `nightlyone/lockfile` module entry with a Go 1.15-compatible `gofrs/flock` pin

## Verification
- `go mod download`
- `go build -mod=readonly lc0_main.go`
- `GOOS=windows GOARCH=amd64 go build -mod=readonly -o /tmp/lc0-training-client.exe lc0_main.go`